### PR TITLE
Improve Apex annotations formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## Formatting Changes
 
+- Fix annotation names to always be upper camel case
+- Add spaces between annotation arguments keys and values
 - Make closing bracket remain on the same line if the block is empty
 - Add additional space before the opening bracket for the collections initialization: `new Map<> {`
 - Fix SOQL Time literals always getting printed in UTC timezone.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -440,3 +440,25 @@ export const ALLOW_DANGLING_COMMENTS = [
   APEX_TYPES.INTERFACE_DECLARATION,
   APEX_TYPES.BLOCK_STATEMENT,
 ];
+
+export const AVAILABLE_ANNOTATIONS = [
+  "AuraEnabled",
+  "Deprecated",
+  "Future",
+  "InvocableMethod",
+  "InvocableVariable",
+  "JsonAccess",
+  "NamespaceAccessible",
+  "RemoteAction",
+  "SuppressWarnings",
+  "TestSetup",
+  "TestVisible",
+  "IsTest",
+  "RestResource",
+  "ReadOnly",
+  "HttpGet",
+  "HttpPost",
+  "HttpPut",
+  "HttpPatch",
+  "HttpDelete",
+];

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -11,6 +11,7 @@ import {
   checkIfParentIsDottedExpression,
   getPrecedence,
   isBinaryish,
+  normalizeAnnotationName,
 } from "./util";
 import {
   ASSIGNMENT,
@@ -666,7 +667,7 @@ function handleAnnotation(path: AstPath, print: printFn): Doc {
     }, "comments");
   }
   parts.push("@");
-  parts.push(path.call(print, "name", "value"));
+  parts.push(normalizeAnnotationName(`${path.call(print, "name", "value")}`));
   if (parameterDocs.length > 0) {
     parameterParts.push("(");
     parameterParts.push(softline);
@@ -683,7 +684,9 @@ function handleAnnotation(path: AstPath, print: printFn): Doc {
 function handleAnnotationKeyValue(path: AstPath, print: printFn): Doc {
   const parts: Doc[] = [];
   parts.push(path.call(print, "key", "value"));
+  parts.push(" ");
   parts.push("=");
+  parts.push(" ");
   parts.push(path.call(print, "value"));
   return concat(parts);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,7 +4,11 @@ import { join } from "path";
 import { accessSync } from "fs";
 
 import jorje from "../vendor/apex-ast-serializer/typings/jorje";
-import { APEX_TYPES, APEX_TYPES as apexTypes } from "./constants";
+import {
+  APEX_TYPES,
+  APEX_TYPES as apexTypes,
+  AVAILABLE_ANNOTATIONS,
+} from "./constants";
 
 export type SerializedAst = {
   [APEX_TYPES.PARSER_OUTPUT]: jorje.ParserOutput;
@@ -257,4 +261,13 @@ export function getSerializerBinDirectory(): string {
     serializerBin = join(__dirname, "../../vendor/apex-ast-serializer/bin");
   }
   return serializerBin;
+}
+
+export function normalizeAnnotationName(name: string): string {
+  return (
+    AVAILABLE_ANNOTATIONS.find(
+      (ann) =>
+        ann.localeCompare(name, undefined, { sensitivity: "accent" }) === 0,
+    ) || name
+  );
 }

--- a/tests/annotated_class_false_param/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/annotated_class_false_param/__snapshots__/jsfmt.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`Format apex: AnnotatedFalseParamClass.cls: AnnotatedFalseParamClass.cls
 {}
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@IsTest(SeeAllData=false)
+@IsTest(SeeAllData = false)
 class AnnotatedFalseParamClass {}
 
 `;

--- a/tests/annotated_class_true_param/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/annotated_class_true_param/__snapshots__/jsfmt.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`Format apex: AnnotatedTrueParamClass.cls: AnnotatedTrueParamClass.cls 1
 {}
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@IsTest(SeeAllData=true)
+@IsTest(SeeAllData = true)
 class AnnotedTrueParamClass {}
 
 `;

--- a/tests/annotated_method/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/annotated_method/__snapshots__/jsfmt.spec.ts.snap
@@ -35,7 +35,7 @@ class topLevelClass {
   @AuraEnabled
   public String someProperty { get; set; }
 
-  @AuraEnabled(cacheable=true continuation=true)
+  @AuraEnabled(cacheable = true continuation = true)
   public static Account getAccount(Id accountId) {}
 
   @SuppressWarnings('PMD.ApexCRUDViolation')
@@ -44,19 +44,23 @@ class topLevelClass {
   @SuppressWarnings('PMD.ApexCRUDViolation, PMD.AnotherViolation')
   void anotherMethod() {}
 
-  @InvocableMethod(label='Label' description='Description' category='Category')
+  @InvocableMethod(
+    label = 'Label'
+    description = 'Description'
+    category = 'Category'
+  )
   List<String> getAccountNames(List<ID> ids) {}
 
-  @InvocableMethod(callout=true)
+  @InvocableMethod(callout = true)
   List<String> getAccountNamesWithCallout(List<ID> ids) {}
 
   @InvocableMethod
   public static List<Results> execute(List<Requests> requestList) {}
 
   @InvocableVariable(
-    label='Records for Input'
-    description='yourDescription'
-    required=true
+    label = 'Records for Input'
+    description = 'yourDescription'
+    required = true
   )
   public List<SObject> inputCollection;
 }

--- a/tests/comments/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.ts.snap
@@ -773,8 +773,8 @@ class Comments {
 /**
  * ApexDoc for class
  */
-@isTest(
-  seeAllData=true // Class annotation inline comment 1
+@IsTest(
+  seeAllData = true // Class annotation inline comment 1
   //isParallel = false // Class annotation inline comment 2
 )
 class Comments {
@@ -1464,40 +1464,40 @@ class Comments {
     );
   }
 
-  @isTest // Decorator Trailing Inline Comment 1
+  @IsTest // Decorator Trailing Inline Comment 1
   void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
-  /* Decorator Leading Block Comment 1 */ @isTest
+  /* Decorator Leading Block Comment 1 */ @IsTest
   void leadingCommentBeforeAnnotation() {
     System.debug('Hi');
   }
 
-  @isTest // Decorator Trailing Inline Comment 2
+  @IsTest // Decorator Trailing Inline Comment 2
   @AuraEnabled // Decorater Trailing Inline Comment 3
   void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
-  @isTest /* Decorator Trailing Block Comment 1 */
+  @IsTest /* Decorator Trailing Block Comment 1 */
   void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
-  /* Decorator Leading Block Comment 1 */ @isTest
+  /* Decorator Leading Block Comment 1 */ @IsTest
   void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
-  @isTest(
-    seeAllData=true // Method annotation inline comment 1
+  @IsTest(
+    seeAllData = true // Method annotation inline comment 1
     //isParallel = false // Method annotation inline comment 2
   )
   void methodAnnotationInlineComment() {}
 
-  @isTest(
-    seeAllData=true /* Method annotation block comment 1 */
+  @IsTest(
+    seeAllData = true /* Method annotation block comment 1 */
     /*isParallel = false // Method annotation block comment 2 */
   )
   void methodAnnotationBlockComment() {}

--- a/tests/run_as/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/run_as/__snapshots__/jsfmt.spec.ts.snap
@@ -34,7 +34,7 @@ class RunAsClass {
 }
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@isTest
+@IsTest
 class RunAsClass {
   static testMethod void runAsTest() {
     User userOne = [SELECT Id FROM User LIMIT 1];

--- a/tests/simple_method/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/simple_method/__snapshots__/jsfmt.spec.ts.snap
@@ -148,8 +148,8 @@ public class SimpleMethod implements FirstSampleInterface, SecondSampleInterface
   }
 
   @InvocableMethod(
-    label='Insert Accounts'
-    description='Inserts the accounts specified and returns the IDs of the new accounts.'
+    label = 'Insert Accounts'
+    description = 'Inserts the accounts specified and returns the IDs of the new accounts.'
   )
   public static List<ID> insertAccounts(List<Account> accounts) {
     return null;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
1. Fix annotation names to always be upper camel case
2. Add spaces between annotation arguments keys and values

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
