### PR TITLE
A modifier is deleted from the method declaration when annotation is followed by a comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .idea
+.sfdx
 *.iml
 coverage
 tests/local_only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Formatting Changes
 
+- Fix an issue with the `apexSortModifiers` option which removes a method modifier if there is an own-line comment between annotation and method ([issue](https://github.com/IlyaMatsuev/prettier-plugin-apex/issues/13)).
 - Fix an issue with the `apexExplicitAccessModifier` option when the `webservice` method gets an access modifier ([issue](https://github.com/IlyaMatsuev/prettier-plugin-apex/issues/12)).
 - Fix an issue with the `apexExplicitAccessModifier` option when the method parameters get `private` modifier ([issue](https://github.com/IlyaMatsuev/prettier-plugin-apex/issues/11)).
 - Change the formatting of `webservice` and `testmethod` modifiers to be always printed in lowercase instead of `webService` and `testMethod`.

--- a/tests/comments/Comments.cls
+++ b/tests/comments/Comments.cls
@@ -807,8 +807,36 @@ class Comments {
     while (true);
   }
 
+  // Some comment here
+  @isTest(seeAllData = true)
+  // Dangling comment
+  public static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  @isTest(seeAllData = true)
+  /* Dangling comment */
+  public static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  @isTest(seeAllData = true)
+  /* 
+    Dangling comment 
+  */
+  // Comment
+  public static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
   @isTest // Decorator Trailing Inline Comment 1
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  // Some comment here
+  @isTest // Decorator Trailing Inline Comment 1
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
@@ -819,17 +847,17 @@ class Comments {
 
   @isTest // Decorator Trailing Inline Comment 2
   @AuraEnabled // Decorater Trailing Inline Comment 3
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
   @isTest /* Decorator Trailing Block Comment 1 */
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
   /* Decorator Leading Block Comment 1 */ @isTest
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 

--- a/tests/comments/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.ts.snap
@@ -810,8 +810,36 @@ class Comments {
     while (true);
   }
 
+  // Some comment here
+  @isTest(seeAllData = true)
+  // Dangling comment
+  public static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  @isTest(seeAllData = true)
+  /* Dangling comment */
+  public static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  @isTest(seeAllData = true)
+  /* 
+    Dangling comment 
+  */
+  // Comment
+  public static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
   @isTest // Decorator Trailing Inline Comment 1
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  // Some comment here
+  @isTest // Decorator Trailing Inline Comment 1
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
@@ -822,17 +850,17 @@ class Comments {
 
   @isTest // Decorator Trailing Inline Comment 2
   @AuraEnabled // Decorater Trailing Inline Comment 3
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
   @isTest /* Decorator Trailing Block Comment 1 */
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
   /* Decorator Leading Block Comment 1 */ @isTest
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
@@ -1670,8 +1698,36 @@ class Comments {
     );
   }
 
+  // Some comment here
+  @isTest(seeAllData=true)
+  // Dangling comment
+  public static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  @isTest(seeAllData=true)
+  /* Dangling comment */
+  public static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  @isTest(seeAllData=true)
+  /* 
+    Dangling comment 
+  */
+  // Comment
+  public static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
   @isTest // Decorator Trailing Inline Comment 1
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  // Some comment here
+  @isTest // Decorator Trailing Inline Comment 1
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
@@ -1682,17 +1738,17 @@ class Comments {
 
   @isTest // Decorator Trailing Inline Comment 2
   @AuraEnabled // Decorater Trailing Inline Comment 3
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
   @isTest /* Decorator Trailing Block Comment 1 */
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 
   /* Decorator Leading Block Comment 1 */ @isTest
-  void trailingCommentAfterMethodName() {
+  static void trailingCommentAfterMethodName() {
     System.debug('Hi');
   }
 

--- a/tests/explicit_access_modifier/ExplicitAccessModifier.cls
+++ b/tests/explicit_access_modifier/ExplicitAccessModifier.cls
@@ -147,4 +147,29 @@ with sharing virtual   public @IsTest class ExplicitAccessModifier
             final Season[] values = Season.values();
         }
     }
+
+    @isTest(seeAllData = true)
+    // Dangling comment
+    static void trailingCommentAfterMethodName() {
+        System.debug('Hi');
+    }
+
+    @isTest(seeAllData = true)
+    /* Dangling comment */
+    static void trailingCommentAfterMethodName() {
+        System.debug('Hi');
+    }
+
+    @isTest(seeAllData = true)
+    /* 
+      Dangling comment
+    */
+    static void trailingCommentAfterMethodName() {
+        System.debug('Hi');
+    }
+
+    @isTest // Decorator Trailing Inline Comment 1
+    public static void trailingCommentAfterMethodName() {
+        System.debug('Hi');
+    }
 }

--- a/tests/explicit_access_modifier/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/explicit_access_modifier/__snapshots__/jsfmt.spec.ts.snap
@@ -150,6 +150,31 @@ with sharing virtual   public @IsTest class ExplicitAccessModifier
             final Season[] values = Season.values();
         }
     }
+
+    @isTest(seeAllData = true)
+    // Dangling comment
+    static void trailingCommentAfterMethodName() {
+        System.debug('Hi');
+    }
+
+    @isTest(seeAllData = true)
+    /* Dangling comment */
+    static void trailingCommentAfterMethodName() {
+        System.debug('Hi');
+    }
+
+    @isTest(seeAllData = true)
+    /* 
+      Dangling comment
+    */
+    static void trailingCommentAfterMethodName() {
+        System.debug('Hi');
+    }
+
+    @isTest // Decorator Trailing Inline Comment 1
+    public static void trailingCommentAfterMethodName() {
+        System.debug('Hi');
+    }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 @IsTest
@@ -307,6 +332,31 @@ public with sharing virtual class ExplicitAccessModifier {
       String s = Season.SPRING.name();
       final Season[] values = Season.values();
     }
+  }
+
+  @isTest(seeAllData=true)
+  // Dangling comment
+  private static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  @isTest(seeAllData=true)
+  /* Dangling comment */
+  private static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  @isTest(seeAllData=true)
+  /* 
+      Dangling comment
+    */
+  private static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
+  }
+
+  @isTest // Decorator Trailing Inline Comment 1
+  public static void trailingCommentAfterMethodName() {
+    System.debug('Hi');
   }
 }
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
This PR will fix the issue with the `apexSortModifiers` option which removes a method modifier if there is an own-line comment between annotation and method.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
