### PR TITLE
The apexExplicitAccessModifier doesn't work properly for trigger variables

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -10,6 +10,7 @@ import {
   checkIfParentIsDottedExpression,
   getPrecedence,
   isBinaryish,
+  isTriggerSource,
   normalizeAnnotationName,
   normalizeTypeName,
 } from "./util";
@@ -127,6 +128,7 @@ function normalizeModifiers(modifiers: Doc[], options: ParserOptions): Doc[] {
   // Add default modifier (private) if the option is enabled
   if (
     options.apexExplicitAccessModifier &&
+    !isTriggerSource(options.filepath) &&
     options.parser === "apex" &&
     !hasModifiers(
       nonAnnotationModifiers,
@@ -1384,7 +1386,7 @@ function handleVariableDeclarations(
   // Modifiers
   if (path.getParentNode()["@class"] === APEX_TYPES.FIELD_MEMBER) {
     // Add private access modifier if this is a class field
-    modifierDocs = normalizeModifiers(path.map(print, "modifiers"), options);
+    modifierDocs = normalizeModifiers(modifierDocs, options);
   }
   parts.push(join("", modifierDocs));
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -65,6 +65,15 @@ export function isApexDocComment(comment: jorje.BlockComment): boolean {
   );
 }
 
+/**
+ * Check if the file is a trigger source by the provided file path
+ * @param filePath The absolute or relative file path
+ * @returns true if the source file is for Salesforce trigger
+ */
+export function isTriggerSource(filePath: string): boolean {
+  return filePath.endsWith(".trigger");
+}
+
 export function checkIfParentIsDottedExpression(path: AstPath): boolean {
   const node = path.getValue();
   const parentNode = path.getParentNode();

--- a/tests/trigger_explicit_access_modifier/TriggerExplicitAccessModifier.trigger
+++ b/tests/trigger_explicit_access_modifier/TriggerExplicitAccessModifier.trigger
@@ -1,0 +1,13 @@
+trigger TriggerExplicitAccessModifier on Account(before delete, before insert, before update,
+  after delete, after insert, after update, after undelete, before undelete) {
+    Triggers.IHandler handler = new SomeHandler();
+    Triggers.dispatcher
+        .bind(TriggerOperation.BEFORE_INSERT, new SomeHandler())
+        .bind(TriggerOperation.BEFORE_INSERT, new SomeHandler())
+        .bindAsync(TriggerOperation.AFTER_INSERT, handler)
+        .bindAsync(TriggerOperation.AFTER_DELETE, handler)
+        .bindAsync(TriggerOperation.AFTER_UNDELETE, handler)
+        .run(new SomeHandler());
+        Integer q, w = 2;
+        String ww;
+}

--- a/tests/trigger_explicit_access_modifier/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/trigger_explicit_access_modifier/__snapshots__/jsfmt.spec.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Format apex: TriggerExplicitAccessModifier.trigger: TriggerExplicitAccessModifier.trigger 1`] = `
+trigger TriggerExplicitAccessModifier on Account(before delete, before insert, before update,
+  after delete, after insert, after update, after undelete, before undelete) {
+    Triggers.IHandler handler = new SomeHandler();
+    Triggers.dispatcher
+        .bind(TriggerOperation.BEFORE_INSERT, new SomeHandler())
+        .bind(TriggerOperation.BEFORE_INSERT, new SomeHandler())
+        .bindAsync(TriggerOperation.AFTER_INSERT, handler)
+        .bindAsync(TriggerOperation.AFTER_DELETE, handler)
+        .bindAsync(TriggerOperation.AFTER_UNDELETE, handler)
+        .run(new SomeHandler());
+        Integer q, w = 2;
+        String ww;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+trigger TriggerExplicitAccessModifier on Account(
+  before delete,
+  before insert,
+  before update,
+  after delete,
+  after insert,
+  after update,
+  after undelete,
+  before undelete
+) {
+  Triggers.IHandler handler = new SomeHandler();
+  Triggers.dispatcher
+    .bind(TriggerOperation.BEFORE_INSERT, new SomeHandler())
+    .bind(TriggerOperation.BEFORE_INSERT, new SomeHandler())
+    .bindAsync(TriggerOperation.AFTER_INSERT, handler)
+    .bindAsync(TriggerOperation.AFTER_DELETE, handler)
+    .bindAsync(TriggerOperation.AFTER_UNDELETE, handler)
+    .run(new SomeHandler());
+  Integer q, w = 2;
+  String ww;
+}
+
+`;

--- a/tests/trigger_explicit_access_modifier/jsfmt.spec.ts
+++ b/tests/trigger_explicit_access_modifier/jsfmt.spec.ts
@@ -1,0 +1,4 @@
+runSpec(__dirname, ["apex"], {
+  apexExplicitAccessModifier: true,
+  astCompareDisabled: true,
+});


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

This PR prevents the `apexExplicitAccessModifier` feature to be applied for trigger files.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
