### PR TITLE
Allow an empty line for classes and interfaces declarations

### DIFF
--- a/CHANGELOG.examples.md
+++ b/CHANGELOG.examples.md
@@ -2,6 +2,43 @@
 
 ## Formatting Changes
 
+### Allow an extra line break in the beginning of the class/interface declaration
+
+It's possible now to have an additional line break in the begginning of a class body to improve the readability. But it's not forced. Meaning that if it was not added in the source code, it will not be added by Prettier.
+
+Input:
+
+```java
+class Test {
+
+
+    private class InnerTest {
+        public Integer q;
+    }
+
+    private class InnerTest2 {
+
+        public Integer q;
+    }
+}
+```
+
+Output:
+
+```java
+class Test {
+
+    private class InnerTest {
+        public Integer q;
+    }
+
+    private class InnerTest2 {
+
+        public Integer q;
+    }
+}
+```
+
 ### Change the formatting behaviour for the `apexFormatInlineComments` option
 
 Now this option is a `choice`. Below is the input code snippet and the examples of how it could be formatted with different option values:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Formatting Changes
 
+- Allow an extra line break in the beginning of the class/interface declaration [issue](https://github.com/IlyaMatsuev/prettier-plugin-apex/issues/25).
 - Change the formatting behaviour for `apexFormatInlineComments`. It's now a choice option. Check out how it can be used in the [changelog examples](/CHANGELOG.examples.md) [issue](https://github.com/IlyaMatsuev/prettier-plugin-apex/issues/22).
 
 # 2.1.0

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -11,6 +11,7 @@ import {
   getPrecedence,
   isBinaryish,
   isTriggerSource,
+  doesBlockHaveExtraNewLine,
   normalizeAnnotationName,
   normalizeTypeName,
 } from "./util";
@@ -737,10 +738,19 @@ function handleInterfaceDeclaration(
   }
   parts.push(" ");
   parts.push("{");
+
+  const nodeOriginalText = options.originalText.substring(
+    options.locStart(node),
+    options.locEnd(node),
+  );
+  if (doesBlockHaveExtraNewLine(nodeOriginalText)) {
+    parts.push(hardline);
+  }
+
   if (danglingCommentDocs.length > 0) {
-    parts.push(indent(concat([hardline, ...danglingCommentDocs])));
+    parts.push(indent([hardline, ...danglingCommentDocs]));
   } else if (memberDocs.length > 0) {
-    parts.push(indent(concat([hardline, ...memberDocs])));
+    parts.push(indent([hardline, ...memberDocs]));
   }
   if (
     danglingCommentDocs.length ||
@@ -810,10 +820,19 @@ function handleClassDeclaration(
   }
   parts.push(" ");
   parts.push("{");
+
+  const nodeOriginalText = options.originalText.substring(
+    options.locStart(node),
+    options.locEnd(node),
+  );
+  if (doesBlockHaveExtraNewLine(nodeOriginalText)) {
+    parts.push(hardline);
+  }
+
   if (danglingCommentDocs.length > 0) {
-    parts.push(indent(concat([hardline, ...danglingCommentDocs])));
+    parts.push(indent([hardline, ...danglingCommentDocs]));
   } else if (memberDocs.length > 0) {
-    parts.push(indent(concat([hardline, ...memberDocs])));
+    parts.push(indent([hardline, ...memberDocs]));
   }
   if (
     danglingCommentDocs.length ||

--- a/src/util.ts
+++ b/src/util.ts
@@ -86,6 +86,20 @@ export function isTriggerSource(filePath: string): boolean {
   return filePath.endsWith(".trigger");
 }
 
+/**
+ * Check if the block text has an extra new line in it
+ * @param blockText The block text content
+ * @returns true if there is more than 1 new line in the block
+ */
+export function doesBlockHaveExtraNewLine(blockText: string): boolean {
+  const openBraceIndex = blockText.indexOf("{");
+  if (openBraceIndex === -1) {
+    return false;
+  }
+  const blockTextOnly = blockText.substring(openBraceIndex);
+  return /^{(\s*\n){2,}\s*[^\s}]/.test(blockTextOnly);
+}
+
 export function checkIfParentIsDottedExpression(path: AstPath): boolean {
   const node = path.getValue();
   const parentNode = path.getParentNode();

--- a/tests/apex_types_format/ApexTypesFormat.cls
+++ b/tests/apex_types_format/ApexTypesFormat.cls
@@ -1,4 +1,5 @@
 class ApexTypesFormat {
+          
   private list<String> aCopy = new list<string>(veryLongVariable.getOneSet().getAnotherSet().getYetAnotherSet());
   private static list<string> aCopy = new list<string>(superDuperVeryInsanelyLongVariableNameThatWillSurelyBreak.getOneSet().getAnotherSet().getYetAnotherSet());
 

--- a/tests/apex_types_format/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/apex_types_format/__snapshots__/jsfmt.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Format apex: ApexTypesFormat.cls: ApexTypesFormat.cls 1`] = `
 class ApexTypesFormat {
+          
   private list<String> aCopy = new list<string>(veryLongVariable.getOneSet().getAnotherSet().getYetAnotherSet());
   private static list<string> aCopy = new list<string>(superDuperVeryInsanelyLongVariableNameThatWillSurelyBreak.getOneSet().getAnotherSet().getYetAnotherSet());
 
@@ -105,6 +106,7 @@ class ApexTypesFormat {
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class ApexTypesFormat {
+
   private List<String> aCopy = new List<String>(
     veryLongVariable.getOneSet().getAnotherSet().getYetAnotherSet()
   );

--- a/tests/block_member/BlockMember.cls
+++ b/tests/block_member/BlockMember.cls
@@ -1,4 +1,6 @@
-class BlockMember {
+class BlockMember { 
+
+
   String fieldMemberOne;
   String anotherFieldMember = 'Hello';
   private transient String anotherFieldMemberTwo;
@@ -35,11 +37,16 @@ class BlockMember {
     }
   }
   class StaticStatementBlockMember {
+
     static {
       System.debug('Static Statement Block Member');
     }
   }
   interface InnerInterface {
+    void interfaceMethod();
+  }
+  interface InnerInterface2 {
+
     void interfaceMethod();
   }
   enum TestEnum { ONE, TWO }

--- a/tests/block_member/__snapshots__/jsfmt.spec.ts.snap
+++ b/tests/block_member/__snapshots__/jsfmt.spec.ts.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Format apex: BlockMember.cls: BlockMember.cls 1`] = `
-class BlockMember {
+class BlockMember { 
+
+
   String fieldMemberOne;
   String anotherFieldMember = 'Hello';
   private transient String anotherFieldMemberTwo;
@@ -38,6 +40,7 @@ class BlockMember {
     }
   }
   class StaticStatementBlockMember {
+
     static {
       System.debug('Static Statement Block Member');
     }
@@ -45,11 +48,16 @@ class BlockMember {
   interface InnerInterface {
     void interfaceMethod();
   }
+  interface InnerInterface2 {
+
+    void interfaceMethod();
+  }
   enum TestEnum { ONE, TWO }
 }
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class BlockMember {
+
   String fieldMemberOne;
   String anotherFieldMember = 'Hello';
   private transient String anotherFieldMemberTwo;
@@ -92,11 +100,16 @@ class BlockMember {
     }
   }
   class StaticStatementBlockMember {
+
     static {
       System.debug('Static Statement Block Member');
     }
   }
   interface InnerInterface {
+    void interfaceMethod();
+  }
+  interface InnerInterface2 {
+
     void interfaceMethod();
   }
   enum TestEnum {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

This PR makes it possible to have an extra line break in the beginning of the class/interface declaration.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing formatting output/API or CLI) I’ve added my changes to the `CHANGELOG.md` file in the `Unreleased` section.
- [x] I’ve read the [contributing guidelines](https://github.com/dangmai/prettier-plugin-apex/blob/master/CONTRIBUTING.md).
